### PR TITLE
Fix getting a hash, re-enable tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ There is an example application included in the `example_app` directory that uti
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake rspec` to run the
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the
 tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version,

--- a/lib/gkv/database.rb
+++ b/lib/gkv/database.rb
@@ -12,7 +12,7 @@ module Gkv
     end
 
     def set(key, value)
-      update_items(key, value.to_s)
+      update_items(key, YAML.dump(value))
       key
     end
 

--- a/lib/gkv/git.rb
+++ b/lib/gkv/git.rb
@@ -11,7 +11,7 @@ module Gkv
 
     def write_tmpfile(data)
       f = File.open('tmp.txt', 'w+')
-      f.write(data.to_s)
+      f.write(data)
       f.close
     end
 
@@ -24,10 +24,10 @@ module Gkv
     def update_items(key, value)
       if $ITEMS.keys.include? key
         history = $ITEMS[key]
-        history << Gkv::GitFunctions.hash_object(value.to_s)
+        history << Gkv::GitFunctions.hash_object(value)
         $ITEMS[key] = history
       else
-        $ITEMS[key] = [Gkv::GitFunctions.hash_object(value.to_s)]
+        $ITEMS[key] = [Gkv::GitFunctions.hash_object(value)]
       end
     end
   end

--- a/spec/gkv_spec.rb
+++ b/spec/gkv_spec.rb
@@ -16,33 +16,33 @@ describe Gkv do
 #  end
 
   context "on set" do
-#    it 'sets a key' do
-#      db.set('Apples', 10)
-#      expect(db.get('Apples')).to eq 10
-#    end
-#
-#    it 'modifies a key' do
-#      db.set('Apples', 12)
-#      db.set('Apples', 10)
-#      expect(db.get('Apples')).to eq 10.0
-#    end
-#
-#    it 'keeps a history of a keys values' do
-#      db.set('Pants', 10)
-#      db.set('Pants', 'oats')
-#      expect(db.get_version(1, 'Pants')).to eq 10
-#      expect(db.get_version(2, 'Pants')).to eq 'oats'
-#    end
-#
-#    it 'can return a float type' do
-#      db.set('Pants', '10')
-#      expect(db.get('Pants')).to eq 10.0
-#    end
-#
-#    it 'can return an integer type' do
-#      db.set('Pants', '10')
-#      expect(db.get('Pants')).to eq 10
-#    end
+    it 'sets a key' do
+      db.set('Apples', 10)
+      expect(db.get('Apples')).to eq 10
+    end
+
+    it 'modifies a key' do
+      db.set('Apples', 12)
+      db.set('Apples', 10)
+      expect(db.get('Apples')).to eq 10
+    end
+
+    it 'keeps a history of a keys values' do
+      db.set('Pants', 10)
+      db.set('Pants', 'oats')
+      expect(db.get_version(1, 'Pants')).to eq 10
+      expect(db.get_version(2, 'Pants')).to eq 'oats'
+    end
+
+    it 'can return a float type' do
+      db.set('Pants', 10.0)
+      expect(db.get('Pants')).to eq 10.0
+    end
+
+    it 'can return an integer type' do
+      db.set('Pants', 10)
+      expect(db.get('Pants')).to eq 10
+    end
 
     context "when saving hashes" do
       it 'deals with ruby 2 hashes' do
@@ -51,14 +51,13 @@ describe Gkv do
         desired = {key: 'value'}
         expect(res).to be_an_instance_of Hash
         expect(res).to eq desired
-        expect(res.to_s).to eq '{"key"=>"value"}'
       end
 
       it 'deals with old hash syntax' do
         db.set('stuff', {:key => "value"})
         res = db.get('stuff')
         expect(res).to be_an_instance_of Hash
-        expect(res.to_s).to eq '{"key"=>"value"}'
+        expect(res).to eq({:key=>"value"})
       end
 
       it 'handles created hash via literals' do
@@ -67,59 +66,31 @@ describe Gkv do
         db.set('stuff', hash)
         res = db.get('stuff')
         expect(res).to be_an_instance_of Hash
-        expect(res.to_s).to eq '{"stuff"=>"thing"}'
-      end
-
-      it 'for some fucked up reason works fine and returns a hash with a string setting it (new hash syntax)' do
-        db.set('stuff', '{key: "value"}')
-        result = {key: 'value'}
-        expect(db.get('stuff')).to eq result
-        expect(db.get('stuff').class).to eq Hash
-      end
-
-      it 'for some fucked up reason works fine and returns a hash with a string setting it (old hash syntax)' do
-        db.set('stuff', '{:key => "value"}')
-        result = {key: 'value'}
-        expect(db.get('stuff')).to eq result
-        expect(db.get('stuff').class).to eq Hash
-      end
-
-      it 'for some fucked up reason works fine and returns a hash with a string setting it (string key + val, no sym, new hash)' do
-        db.set('stuff', '{"key": "value"}')
-        result = {key: 'value'}
-        expect(db.get('stuff')).to eq result
-        expect(db.get('stuff').class).to eq Hash
-      end
-
-      it 'for some fucked up reason works fine and returns a hash with a string setting it (string key + val, no sym, old hash)' do
-        db.set('stuff', '{"key" => "value"}')
-        result = {key: 'value'}
-        expect(db.get('stuff')).to eq result
-        expect(db.get('stuff').class).to eq Hash
+        expect(res).to eq({:stuff=>"thing"})
       end
     end
 
-#    it 'can return an array type' do
-#      db.set('favorites', ['pants', 'lack of pants', 'party pants'])
-#      expect(db.get('favorites')).to eq ['pants', 'lack of pants', 'party pants']
-#    end
-#
-#    it 'can return a bool type' do
-#      db.set('stuff', true)
-#      expect(db.get('stuff')).to eq true
-#    end
+    it 'can return an array type' do
+      db.set('favorites', ['pants', 'lack of pants', 'party pants'])
+      expect(db.get('favorites')).to eq ['pants', 'lack of pants', 'party pants']
+    end
+
+    it 'can return a bool type' do
+      db.set('stuff', true)
+      expect(db.get('stuff')).to eq true
+    end
   end
 
-#  context "on get" do
-#    it 'returns the key when a key is set' do
-#      expect(db.set('Apples', '10')).to eq 'Apples'
-#    end
-#
-#    it 'can get all stored items' do
-#      db.set('ants', 10)
-#      db.set('bob', 'pants')
-#      db.set('cants', 10)
-#      expect(db.all).to eq [{ 'ants': 10 }, { 'bob': 'pants' }, { 'cants': 10 }]
-#    end
-#  end
+  context "on get" do
+    it 'returns the key when a key is set' do
+      expect(db.set('Apples', '10')).to eq 'Apples'
+    end
+
+    it 'can get all stored items' do
+      db.set('ants', 10)
+      db.set('bob', 'pants')
+      db.set('cants', 10)
+      expect(db.all).to eq [{ 'ants': 10 }, { 'bob': 'pants' }, { 'cants': 10 }]
+    end
+  end
 end


### PR DESCRIPTION
Data was retrieved from the store using `YAML.load`, but was inserted with `.to_s`. I changed the `set` method to use `YAML.dump` instead.

Re-enabled all the tests that weren't "fucked up"