### PR TITLE
add debt ceiling to test suite

### DIFF
--- a/.debt_ceiling.rb
+++ b/.debt_ceiling.rb
@@ -1,0 +1,5 @@
+DebtCeiling.configure do |c|
+  c.whitelist = %w(bin lib bench example)
+  c.max_debt_per_module = 30
+  c.debt_ceiling = 75
+end

--- a/gkv.gemspec
+++ b/gkv.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "debt_ceiling"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,6 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'gkv'
+require 'debt_ceiling'
+RSpec.configure do |config|
+  config.after(:all) { DebtCeiling.audit }
+end


### PR DESCRIPTION
@ybur-yug hope this looks good, feel free to mess with values or play with other customization options, but this is similar to what debt ceiling uses to self host for its own tests.  Could arguably add as an explicit test instead of using spec_helper I guess?  but this seems clean and simple.  Tempted to make a bot that PR's this changes to lots of ruby projects :-)