### PR TITLE
fix shell injection and setting values containing double quotes

### DIFF
--- a/lib/gkv/git.rb
+++ b/lib/gkv/git.rb
@@ -1,9 +1,15 @@
+require "open3"
+
 module Gkv
   module GitFunctions
     extend self
 
     def hash_object(data)
-      `echo "#{data}" | git hash-object -w --stdin`.strip!
+      Open3.popen3("git hash-object -w --stdin") do |stdin, stdout, stderr|
+        stdin.write data
+        stdin.close
+        stdout.read.strip
+      end
     end
 
     def cat_file(hash)

--- a/spec/gkv_spec.rb
+++ b/spec/gkv_spec.rb
@@ -46,6 +46,11 @@ describe Gkv do
       expect(db.get_version(2, 'Pants')).to eq 'oats'
     end
 
+    it 'can set values containing quotes' do
+      db['TestingQuotes'] = %(single ' and double " quote)
+      expect(db['TestingQuotes']).to eq %(single ' and double " quote)
+    end
+
     it 'can return a float type' do
       load_db([{ 'Pants' => 10.0 }])
       expect(db.get('Pants')).to eq 10.0


### PR DESCRIPTION
Shell injection was possible due to passing the value on the command
line using string interpolation. Now using open3 to pass the data to
stdin. This also fixes setting values containing double quotes.

This would have been fixed when getting to the `Stop wrapping git via it's CLI` task in the README, but I wanted to fix it now anyway.
